### PR TITLE
feat: stringify buffers

### DIFF
--- a/src/serializers/JSONSerializer/index.test.ts
+++ b/src/serializers/JSONSerializer/index.test.ts
@@ -1,11 +1,16 @@
 import { JSONSerializer } from '.'
 
-describe(`when serializing an error`, () => {
-    const error = new Error('example')
-    const got = JSONSerializer({ error })
-
+describe(`when serializing errors`, () => {
     test('should stringify the error', () => {
+        const got = JSONSerializer({ error: new Error('example') })
         expect(got).toEqual(`{"error":"Error: example"}`)
+    })
+})
+
+describe(`when serializing buffers`, () => {
+    test('should stringify the buffer', () => {
+        const got =  JSONSerializer({ word: Buffer.from('example') })
+        expect(got).toEqual(`{"word":"example"}`)
     })
 })
 

--- a/src/serializers/JSONSerializer/index.ts
+++ b/src/serializers/JSONSerializer/index.ts
@@ -13,11 +13,20 @@ function getCircularReplacer() {
             }
             seen.add(value)
         }
-        return replaceErrors(key, value)
+        return toStringers(key, value)
     }
 }
 
-function replaceErrors(_: any, value: any) {
-    if (value instanceof Error) return value.toString()
+// toStringers strigifies some specific types
+function toStringers(_: any, value: any) {
+
+    // error
+    if (value instanceof Error)
+        return value.toString()
+
+    // buffer
+    if (value.type !== undefined && value.type === "Buffer")
+        return Buffer.from(value).toString()
+
     return value
 }


### PR DESCRIPTION
previously Buffers are stringified as objects - eg:
```json
> JSONSerializer({ word: Buffer.from('example') })
{"word":{"type":"Buffer","data":[101,120,97,109,112,108,101]}}
```

this proposal updates the default JSON Serializer to stringify buffers - eg:
```json
> JSONSerializer({ word: Buffer.from('example') })
{"word":"example"}
```