### PR TITLE
fix: 🐛 Ensure undefined is not serialzed

### DIFF
--- a/src/serializers/JSONSerializer/index.test.ts
+++ b/src/serializers/JSONSerializer/index.test.ts
@@ -9,8 +9,15 @@ describe(`when serializing errors`, () => {
 
 describe(`when serializing buffers`, () => {
     test('should stringify the buffer', () => {
-        const got =  JSONSerializer({ word: Buffer.from('example') })
+        const got = JSONSerializer({ word: Buffer.from('example') })
         expect(got).toEqual(`{"word":"example"}`)
+    })
+})
+
+describe(`when serializing undefined objects`, () => {
+    test('should not attempt to serialize', () => {
+        const got = JSONSerializer(undefined)
+        expect(got).toEqual(undefined)
     })
 })
 

--- a/src/serializers/JSONSerializer/index.test.ts
+++ b/src/serializers/JSONSerializer/index.test.ts
@@ -14,10 +14,12 @@ describe(`when serializing buffers`, () => {
     })
 })
 
-describe(`when serializing undefined objects`, () => {
-    test('should not attempt to serialize', () => {
-        const got = JSONSerializer(undefined)
-        expect(got).toEqual(undefined)
+describe(`when serializing undefined or null objects`, () => {
+    test.each([
+        [undefined, undefined],
+        [null, 'null'],
+    ])('should not attempt to serialize', (input, expected) => {
+        expect(JSONSerializer(input)).toEqual(expected)
     })
 })
 

--- a/src/serializers/JSONSerializer/index.ts
+++ b/src/serializers/JSONSerializer/index.ts
@@ -19,8 +19,8 @@ function getCircularReplacer() {
 
 // toStringers strigifies some specific types
 function toStringers(_: any, value: any) {
-    // non-null assertion - exit early
-    if (!value) return value
+    // exit early for null and undefined
+    if (value === undefined || value === null) return value
 
     // error
     if (value instanceof Error) return value.toString()

--- a/src/serializers/JSONSerializer/index.ts
+++ b/src/serializers/JSONSerializer/index.ts
@@ -19,14 +19,11 @@ function getCircularReplacer() {
 
 // toStringers strigifies some specific types
 function toStringers(_: any, value: any) {
-
     // error
-    if (value instanceof Error)
-        return value.toString()
+    if (value instanceof Error) return value.toString()
 
     // buffer
-    if (value.type !== undefined && value.type === "Buffer")
-        return Buffer.from(value).toString()
+    if (value?.type !== undefined && value.type === 'Buffer') return Buffer.from(value).toString()
 
     return value
 }

--- a/src/serializers/JSONSerializer/index.ts
+++ b/src/serializers/JSONSerializer/index.ts
@@ -19,11 +19,14 @@ function getCircularReplacer() {
 
 // toStringers strigifies some specific types
 function toStringers(_: any, value: any) {
+    // non-null assertion - exit early
+    if (!value) return value
+
     // error
     if (value instanceof Error) return value.toString()
 
     // buffer
-    if (value?.type !== undefined && value.type === 'Buffer') return Buffer.from(value).toString()
+    if (value.type === 'Buffer') return Buffer.from(value).toString()
 
     return value
 }


### PR DESCRIPTION
Prior to this change, messages that are 'undefined' are attempted to be serialized - this would cause the following exception to be raised:

```bash
TypeError: Cannot read properties of undefined (reading 'type')
```

After this change, a simple non-null assertion is made to ensure the type of the value is not accessed if the value is undefined